### PR TITLE
change noise to gaussian in clustering maps and subtract their mean

### DIFF
--- a/simulation_code/example.config
+++ b/simulation_code/example.config
@@ -22,7 +22,7 @@
 
 DIST:              LOGNORMAL		            # Field type, either LOGNORMAL, GAUSSIAN or HOMOGENEOUS (no structure).
 RNDSEED:           {seed}       	       	            # Seed for random number generator.
-POISSON:	   1				    # 1-Poisson (2-Gaussian) sample galaxy fields; 0-Do not sample (use expected number).
+POISSON:	   2				    # 1-Poisson (2-Gaussian) sample galaxy fields; 0-Do not sample (use expected number).
 
 ### Cosmology ###
 

--- a/simulation_code/simulate_des_maps.py
+++ b/simulation_code/simulate_des_maps.py
@@ -265,6 +265,7 @@ def run_flask(
         )
         # making this into overdensity
         clustering_maps[i]/=clustering_maps[i].mean()
+        clustering_maps[i] -= 1
 
     for i in range(nbin_source):
         convergence_maps[i] = healpy.smoothing(


### PR DESCRIPTION
This fixes two things I found exploring today:

- the poisson noise when generated in Flask changes a lot when you change to even a very close cosmology. I don't fully understand this, but the same thing happens when trying to generate the noise in numpy, so it's not just a seed / thread thing. I think the algorithm for generating poisson RVs depends on the mean of the previous call.  This sidesteps the whole issue by converting to gaussian noise.

- I tracked the issues in the power spectra down to the monopole - the mean of the maps was currently 1 rather than zero, and for whatever reason this makes namaster go crazy even for the second ell bin.  Subtracting off 1 from the maps so the mean is zero removes the effect.